### PR TITLE
Enable buildgen for repro

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -1,0 +1,1 @@
+python_requirements()

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,0 +1,3 @@
+fsqio.pants.contrib.buildgen.core==1.1.1
+fsqio.pants.contrib.buildgen.jvm==1.1.1
+fsqio.pants.contrib.buildgen.python==1.1.1

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -1,0 +1,21 @@
+# Copyright 2016 Foursquare Labs Inc. All Rights Reserved.
+
+def sjar(org, name, rev, url=None):
+  scala_jar_version = '2.11'
+  return jar(org = org, name = '%s_%s' % (name, scala_jar_version), rev = rev, url = url)
+
+
+jar_library(
+name = 'buildgen-emit-used-symbols',
+ jars = [
+   sjar(org = 'io.fsq', name = 'buildgen-emit-used-symbols', rev = '1.1.0'),
+ ]
+)
+
+
+jar_library(
+ name = 'buildgen-emit-exported-symbols',
+ jars = [
+   sjar(org = 'io.fsq', name = 'buildgen-emit-exported-symbols', rev = '1.1.0'),
+ ]
+)

--- a/pants
+++ b/pants
@@ -17,6 +17,7 @@ PYTHON=${PYTHON:-$(which python2.7)}
 
 PANTS_HOME="${PANTS_HOME:-${HOME}/.cache/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
+BUILDGEN_REQUIREMENTS="3rdparty/python/requirements.txt"
 
 VENV_VERSION=15.0.2
 
@@ -84,6 +85,8 @@ function bootstrap_pants {
       "${staging_dir}/install/bin/python" \
         "${staging_dir}/install/bin/pip" install \
           "${SETUPTOOLS_REQUIREMENT}" "${pants_requirement}" && \
+        "${staging_dir}/install/bin/pip" install \
+            -r "${BUILDGEN_REQUIREMENTS}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}" && \
       mv "${staging_dir}/${pants_version}" "${PANTS_BOOTSTRAP}/${pants_version}"
     ) 1>&2

--- a/pants.ini
+++ b/pants.ini
@@ -1,9 +1,10 @@
 [DEFAULT]
-fsqio_version: 1.1.0
+fsqio_version: 1.1.1
 
 [GLOBAL]
 pants_version: 1.2.0
 
-plugins: +[
-    "fsqio.pants.contrib.buildgen.core==%(fsqio_version)s",
+backend_packages: +[
+    "pants.contrib.buildgen.core",
+    "pants.contrib.buildgen.jvm",
   ]


### PR DESCRIPTION
Some of this is done this way simply because it is old.
I ported buildgen to upstream pants pre pants 1.0.0.
They have added some addiotional levers that would perhaps
make this easier nowadays.

I hope to find time to republish buildgen from fsq.io and
make this a bit simpler. Some notes about what I did:

* This looks to work, although you may have to delete your
old bootstrap location (mine was ~/.cache/pants).

* You need the buildgen jars if you want scala support.

* It also revealed some assumptions of buildgen. It requires
a `test` folder, this could be experimented with since
I believe I added an option.

* It also assumes that there is some scala code if the scala
backend is installed - those could be fixed as needed.

* If you do not need either python or scala, you can remove
that backend. But I don't think core will do anything by itself
and may break.

* The 3rdparty/python/BUILD file is not strictly
necessary but it would be if you added deps you wanted
to import in code later on.